### PR TITLE
🐛  Fix lib distribution on esm and cjs modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ demo-build/
 
 # dist
 dist/
+
+.DS_STORE

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,4 +1,4 @@
-import { hex2rgbOrRgba, hexToRgbOrRgba } from '../dist'
+import { hex2rgbOrRgba, hexToRgbOrRgba } from '../dist/esm'
 
 const whiteHex = '#FFFFFF'
 

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
     "hsla",
     "color-model"
   ],
-  "main": "dist/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
   "files": [
     "dist/"
   ],
-  "types": "dist/index.d.ts",
+  "types": "dist/cjs/index.d.ts",
   "scripts": {
-    "compile": "rm -rf dist/ && tsc --outDir dist",
-    "compile-watch": "rm -rf dist/ && tsc -w --outDir dist",
+    "compile": "rm -rf dist/ && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
+    "compile-watch": "rm -rf dist/ && tsc -p tsconfig.json -w | tsc -p tsconfig-cjs.json -w",
     "format": "prettier src/**/*.ts src/**/**/*.ts --write",
     "lint": "tslint -p tsconfig.json",
     "prepublish": "yarn compile",

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+      "module": "CommonJS",
+      "outDir": "./dist/cjs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "lib": ["esnext", "dom", "dom.iterable"],
     "module": "esnext",
+    "outDir": "./dist/esm",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowJs": true,


### PR DESCRIPTION
This PR

# Adds
- `.DS_STORE` file on `.gitignore` 0fbbdf8

# Fixes
- Lib distribution by compiling it to esm and cjs modules c06dd92
   **closes**: #15 